### PR TITLE
chore: import old stats data on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN ls -lsah out/
 FROM mcr.microsoft.com/dotnet/runtime-deps:8.0
 WORKDIR /app
 COPY --from=build-env /app/src/JustSending/out .
+COPY src/JustSending/stats.json .
 
 VOLUME ["App_Data/"]
 VOLUME ["wwwroot/uploads"]


### PR DESCRIPTION
One-off deployment to import of stats. Not to be merged into main branch.

Before
```json
{
    "Id": -1,
    "Messages": 19,
    "MessagesSizeBytes": 897,
    "Files": 11,
    "FilesSizeBytes": 19739434,
    "Devices": 27,
    "Sessions": 24,
    "Version": 63,
    "DateCreatedUtc": "2025-04-26T09:29:451471597"
}
```

After

```json
{
    "Id": -1,
    "Messages": 14622,
    "MessagesSizeBytes": 2971918,
    "Files": 3021,
    "FilesSizeBytes": 15480608780,
    "Devices": 26564,
    "Sessions": 15596,
    "Version": 1190,
    "DateCreatedUtc": "2025-04-26T09:29:45.1471597"
}
```